### PR TITLE
Agregar github en la data de los miembros

### DIFF
--- a/src/assets/data/members.js
+++ b/src/assets/data/members.js
@@ -37,7 +37,7 @@ const members = [
   {
     username: 'carolina',
     image: 'carolina.jpg',
-    twitter: 'cps543'
+    github: 'carolina-pinzon'
   },
   {
     username: 'nicoavila',

--- a/src/components/organizers/index.js
+++ b/src/components/organizers/index.js
@@ -15,8 +15,8 @@ const Organizers = () => (
         {members.map((member) =>
           (<div className={classJoin('level-item', 'has-text-centered', style.organizer)}>
             <figure>
-              <a target="_blank" aria-label={`Perfil de Twitter de ${member.twitter}`} href={`https://twitter.com/${member.twitter}`} rel="noopener"><img src={`../../assets/images/organizers/${member.image}`} alt={`Perfil de Twitter de ${member.twitter}`} className={style.memberImage}/></a>
-              <p className={style.memberInfo}><a href={`https://twitter.com/${member.twitter}`}>@{member.username}</a></p>
+              <a target="_blank" aria-label={`Perfil de Twitter de ${member.twitter}`} href={member.twitter ? `https://twitter.com/${member.twitter}` : `https://github.com/${member.github}`} rel="noopener"><img src={`../../assets/images/organizers/${member.image}`} alt={`Perfil de Twitter de ${member.twitter}`} className={style.memberImage} /></a>
+              <p className={style.memberInfo}><a href={member.twitter ? `https://twitter.com/${member.twitter}` : `https://github.com/${member.github}`}>@{member.username}</a></p>
             </figure>
           </div>)
         )}


### PR DESCRIPTION
Se agregó una condición al componente /organizers para detectar si el miembro tiene twitter o github, en caso de no tener twitter levanta un link al usuario de github.